### PR TITLE
fix message_all_users method to work with lita-slack slack integration

### DIFF
--- a/lib/lita/handlers/standup.rb
+++ b/lib/lita/handlers/standup.rb
@@ -40,8 +40,9 @@ module Lita
 
       def message_all_users
         @users.each do |user|
-          robot.send_message(user, "Time for standup!")
-          robot.send_message(user, "Please tell me what you did yesterday,
+          source = Lita::Source.new(user: user)
+          robot.send_message(source, "Time for standup!")
+          robot.send_message(source, "Please tell me what you did yesterday,
                                     what you're doing now, and what you're
                                     working on today. Please prepend your
                                     answer with 'standup response'")


### PR DESCRIPTION
ran into a bug where slack.rb was requesting a target object as a Lita::Source object
